### PR TITLE
OpenFAST Configuration file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,12 +50,6 @@ endif (FPE_TRAP_ENABLED)
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
-message("LAPACK_LIBRARIES = ${LAPACK_LIBRARIES}")
-message("BLAS_LIBRARIES = ${BLAS_LIBRARIES}")
-message("LAPACK_LINKER_FLAGS = ${LAPACK_LINKER_FLAGS}")
-message("BLAS_LINKER_FLAGS = ${BLAS_LINKER_FLAGS}")
-
-
 ########################################################################
 # Build rules for FAST Registry
 #
@@ -115,3 +109,32 @@ if(BUILD_DOCUMENTATION)
 endif()
 
 add_subdirectory(glue-codes)
+
+# Install fortran .mod files also to installation directory
+install(CODE
+  "EXECUTE_PROCESS (COMMAND \"${CMAKE_COMMAND}\" -E copy_directory \"${CMAKE_Fortran_MODULE_DIRECTORY}\" \"${CMAKE_INSTALL_PREFIX}/include/openfast/\")")
+
+# Install the library dependency information
+install(EXPORT OpenFASTLibraries
+  DESTINATION lib/cmake/OpenFAST
+  FILE OpenFASTLibraries.cmake)
+
+# Create OpenFAST config so that other codes can find OpenFAST
+include(CMakePackageConfigHelpers)
+
+set(INCLUDE_INSTALL_DIR include/)
+set(LIB_INSTALL_DIR lib/)
+set(FTNMOD_INSTALL_DIR include/openfast/)
+if (BUILD_FAST_CPP_API)
+  set(OpenFAST_HAS_CXX_API TRUE)
+else()
+  set(OpenFAST_HAS_CXX_API FALSE)
+endif()
+
+configure_package_config_file(
+  cmake/OpenFASTConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/OpenFASTConfig.cmake
+  INSTALL_DESTINATION lib/cmake/OpenFAST
+  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR FTNMOD_INSTALL_DIR)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenFASTConfig.cmake
+  DESTINATION lib/cmake/OpenFAST)

--- a/glue-codes/fast-cpp/CMakeLists.txt
+++ b/glue-codes/fast-cpp/CMakeLists.txt
@@ -33,12 +33,14 @@ add_library(openfastcpplib
 target_link_libraries(openfastcpplib
   openfastlib
   ${YAML_LIBRARIES}
-  ${HDF5_LIBRARIES})
+  ${HDF5_LIBRARIES}
+  ${CMAKE_DL_LIBS})
 
 add_executable(openfastcpp
   src/FAST_Prog.cpp)
 
-target_link_libraries(openfastcpp openfastcpplib openfastlib ${MPI_LIBRARIES})
+target_link_libraries(openfastcpp openfastcpplib openfastlib
+  ${MPI_LIBRARIES} ${CMAKE_DL_LIBS})
 
 if(MPI_COMPILE_FLAGS)
   set_target_properties(openfastcpp PROPERTIES
@@ -52,8 +54,8 @@ endif(MPI_LINK_FLAGS)
 
 set_property(TARGET openfastcpp PROPERTY LINKER_LANGUAGE CXX)
 
-
-install(TARGETS openfastcpplib 
+install(TARGETS openfastcpplib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)

--- a/modules-ext/feamooring/CMakeLists.txt
+++ b/modules-ext/feamooring/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(feam_driver feamlib)
 
 
 install(TARGETS feamlib feam_driver
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)

--- a/modules-ext/icedyn/CMakeLists.txt
+++ b/modules-ext/icedyn/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(icedynlib
 target_link_libraries(icedynlib nwtclibs)
 
 install(TARGETS icedynlib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)

--- a/modules-ext/icefloe/CMakeLists.txt
+++ b/modules-ext/icefloe/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(icefloelib ${ICEFLOE_LIBS_SOURCES})
 target_link_libraries(icefloelib nwtclibs)
 
 install(TARGETS icefloelib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)

--- a/modules-ext/map/CMakeLists.txt
+++ b/modules-ext/map/CMakeLists.txt
@@ -21,7 +21,11 @@ file(GLOB MAP_C_HEADERS src/*.h src/*/*.h)
 
 add_library(mapcpplib ${MAP_CLIB_SOURCES} MAP_Types.f90)
 target_include_directories(mapcpplib PUBLIC
-  src/bstring src/cminpack src/lapack src/simclist ${CMAKE_CURRENT_BINARY_DIR})
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/bstring>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/cminpack>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/lapack>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/simclist>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 add_library(maplib
   src/map.f90
@@ -31,7 +35,8 @@ add_library(maplib
   )
 target_link_libraries(maplib mapcpplib nwtclibs)
 
-install(TARGETS maplib mapcpplib 
+install(TARGETS maplib mapcpplib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)

--- a/modules-ext/moordyn/CMakeLists.txt
+++ b/modules-ext/moordyn/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(moordynlib ${MOORDYN_LIBS_SOURCES})
 target_link_libraries(moordynlib nwtclibs)
 
 install(TARGETS moordynlib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)

--- a/modules-local/aerodyn/CMakeLists.txt
+++ b/modules-local/aerodyn/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(aerodyn ${AD_DRIVER_SOURCES})
 target_link_libraries(aerodyn aerodynlib nwtclibs ${CMAKE_DL_LIBS})
 
 install(TARGETS aerodyn aerodynlib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/aerodyn14/CMakeLists.txt
+++ b/modules-local/aerodyn14/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(aerodyn14lib nwtclibs)
 # target_link_libraries(dwm_driver_wind_farm aerodyn14lib)
 
 install(TARGETS aerodyn14lib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/beamdyn/CMakeLists.txt
+++ b/modules-local/beamdyn/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(beamdynlib ${BD_SOURCES})
 target_link_libraries(beamdynlib nwtclibs)
 
 install(TARGETS beamdynlib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/elastodyn/CMakeLists.txt
+++ b/modules-local/elastodyn/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(elastodynlib ${ED_SOURCES})
 target_link_libraries(elastodynlib servodynlib nwtclibs)
 
 install(TARGETS elastodynlib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/extptfm/CMakeLists.txt
+++ b/modules-local/extptfm/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(extptfm_mckflib
 target_link_libraries(extptfm_mckflib nwtclibs)
 
 install(TARGETS extptfm_mckflib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/fast-library/CMakeLists.txt
+++ b/modules-local/fast-library/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(openfastlib
   openfast_postlib openfast_prelib scfastlib foamfastlib)
 
 install(TARGETS openfastlib openfast_prelib openfast_postlib
+  EXPORT ${CMAKE_PROJECT_NAME}Libraries
   RUNTIME DESTINATION lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)

--- a/modules-local/hydrodyn/CMakeLists.txt
+++ b/modules-local/hydrodyn/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(hydrodyn hydrodynlib nwtclibs)
 #target_link_libraries(ss_radiation hydrodynlib nwtclibs)
 
 install(TARGETS hydrodynlib hydrodyn
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/inflowwind/CMakeLists.txt
+++ b/modules-local/inflowwind/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(inflowwind ${IFW_DRIVER_SOURCES})
 target_link_libraries(inflowwind ifwlib ${CMAKE_DL_LIBS})
 
 install(TARGETS inflowwind ifwlib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/nwtc-library/CMakeLists.txt
+++ b/modules-local/nwtc-library/CMakeLists.txt
@@ -63,5 +63,6 @@ add_library(nwtclibs ${NWTCLIBS_SOURCES})
 target_link_libraries(nwtclibs ${LAPACK_LIBRARIES} ${CMAKE_DL_LIBS})
 
 install(TARGETS nwtclibs
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/openfoam/CMakeLists.txt
+++ b/modules-local/openfoam/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(foamfastlib
 target_link_libraries(foamfastlib openfoamtypeslib openfast_prelib nwtclibs)
 
 install(TARGETS openfoamtypeslib foamfastlib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/orcaflex-interface/CMakeLists.txt
+++ b/modules-local/orcaflex-interface/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(orca_driver
 target_link_libraries(orca_driver orcaflexlib)
 
 install(TARGETS orcaflexlib orca_driver
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/servodyn/CMakeLists.txt
+++ b/modules-local/servodyn/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(TMD
 target_link_libraries(TMD servodynlib nwtclibs ${CMAKE_DL_LIBS})
 
 install(TARGETS servodynlib servodyn TMD
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/subdyn/CMakeLists.txt
+++ b/modules-local/subdyn/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(subdyn ${SUBDYN_DRIVER_SOURCES})
 target_link_libraries(subdyn subdynlib nwtclibs)
 
 install(TARGETS subdynlib subdyn
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)

--- a/modules-local/supercontroller/CMakeLists.txt
+++ b/modules-local/supercontroller/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(scfastlib
 target_link_libraries(scfastlib sctypeslib openfast_prelib nwtclibs)
 
 install(TARGETS sctypeslib scfastlib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)


### PR DESCRIPTION
This commit creates an `OpenFASTConfig.cmake` file that can be used to detect a valid OpenFAST install and configure library linking automatically. The design follows Trilinos setup closely and can be used in a similar manner in Nalu's `CMakeLists.txt` 

```
if (NALU_USES_OpenFAST)
    SET(CMAKE_PREFIX_PATH ${OpenFAST_DIR} ${CMAKE_PREFIX_PATH})
    find_package(OpenFAST REQUIRED)
endif()
```

and then in the linking step 

```
if (NALU_USES_OpenFAST)
   target_link_libraries(naluX ... ${OpenFAST_LIBRARIES})
endif()
```

To use this, one has to `make install` the compile OpenFAST into a central location (similar to Trilinos). 