### PR TITLE
fix links and formatting

### DIFF
--- a/docs/source/install_linux.rst
+++ b/docs/source/install_linux.rst
@@ -1,7 +1,7 @@
 Building OpenFAST
 =================
 
-OpenFAST uses the `cmake <https://cmake.org>` build system. We recommend installing OpenFAST using `spack <https://spack.readthedocs.io/en/latest>`. However, we also provide some sample scripts in ``share`` folder if you choose to install without `spack`.
+OpenFAST uses the `CMake <https://cmake.org>`__ build system. We recommend installing OpenFAST using `spack <https://spack.readthedocs.io/en/latest>`__. However, we also provide some sample scripts in ``share`` folder if you choose to install without `spack`.
 
 CMake Build Instructions
 ------------------------
@@ -18,24 +18,23 @@ CMake Build Instructions
 Current CMake Options
 ~~~~~~~~~~~~~~~~~~~~~
 
--  ``DOUBLE_PRECISION`` - Enable/disable ``-DDOUBLE_PRECISION`` flag
-   (Default: ON)
--  ``USE_DLL_INTERFACE`` - Enable dynamic library loading capability
-   (Default: ON)
--  ``CMAKE_BUILD_TYPE`` - Release, Debug builds (Default: Release)
--  ``CMAKE_INSTALL_PREFIX`` - Set desired installation directory
--  ``BUILD_SHARED_LIBS`` - Enable/disable building shared libraries
-   (Default: OFF)
--  ``FPE_TRAP_ENABLED`` - Enable Floating Point Exception trap
--  ``BUILD_CPP_API`` - Enable C++ API
+-  ``BUILD_DOCUMENTATION`` -  Build documentation (Default: OFF)
+-  ``BUILD_FAST_CPP_API`` - Enable building FAST - C++ API (Default: OFF)
+-  ``BUILD_SHARED_LIBS`` - Enable building shared libraries (Default: OFF)
+-  ``CMAKE_BUILD_TYPE`` - Choose the build type: Debug Release (Default: Release)
+-  ``CMAKE_INSTALL_PREFIX`` - Install path prefix, prepended onto install directories.
+-  ``DOUBLE_PRECISION`` - Treat REAL as double precision (Default: ON)
+-  ``FPE_TRAP_ENABLED`` -  Enable Floating Point Exception (FPE) trap in compiler options (Default: OFF)
+-  ``ORCA_DLL_LOAD`` - Enable OrcaFlex library load (Default: OFF)
+-  ``USE_DLL_INTERFACE`` - Enable runtime loading of dynamic libraries (Default: ON)
 
 Dependencies
 ~~~~~~~~~~~~
 
 OpenFAST has the following dependencies:
 
-- ``LAPACK`` libraries provided through the variable ``BLASLIB``,
-- for the ``C++`` API, OpenFAST also depends on `HDF5 <https://support.hdfgroup.org/HDF5/>` (provided by ``HDF5_ROOT``) and `yaml-cpp <https://github.com/jbeder/yaml-cpp>` (provided by ``YAML_ROOT``). 
+- ``LAPACK`` libraries provided through the variable ``BLASLIB``
+- for the C++ API, `HDF5 <https://support.hdfgroup.org/HDF5/>`__ (provided by ``HDF5_ROOT``) and `yaml-cpp <https://github.com/jbeder/yaml-cpp>`__ (provided by ``YAML_ROOT``). 
 
 
 


### PR DESCRIPTION
@gantech 
- rst requires two underscores after the url to render a link
- updated the CMake configuration variables to match whats actually in the CMake config 
